### PR TITLE
Fix pytest coverage failure bug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build container
         run: Ctl/dev/compose.sh build account_django
       - name: Run tests
-        run: Ctl/dev/run.sh run_tests
+        run: Ctl/dev/run.sh -u $(echo "$UID") run_tests
       # upload coverage stats
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/Ctl/dev/run.sh
+++ b/Ctl/dev/run.sh
@@ -3,4 +3,16 @@
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-docker-compose -f $COMPOSE_DIR/docker-compose.yml run account_django $@
+# count number of arguments in the format `-arg value`
+n=1
+while [ $n -le $# ]
+do
+    if [ ${!n:0:1} == "-" ]; then
+        n=$((n + 2))
+    else
+        break
+    fi
+done
+
+# put args in format `-arg value` before service args
+docker-compose -f $COMPOSE_DIR/docker-compose.yml run ${@:1:$n-1} account_django ${@:$n:$#}

--- a/src/account/signals.py
+++ b/src/account/signals.py
@@ -84,13 +84,13 @@ def delete_auto_grant(sender, **kwargs):
 
 @receiver(post_save, sender=OrganizationManagedPermission)
 def set_org_manage_permission(sender, **kwargs):
-    instance = kwargs.get("instance")
+    kwargs.get("instance")
     UpdatePermissions.create_task()
 
 
 @receiver(post_delete, sender=OrganizationManagedPermission)
 def delete_org_manage_permission(sender, **kwargs):
-    instance = kwargs.get("instance")
+    kwargs.get("instance")
     UpdatePermissions.create_task()
 
 

--- a/src/tests/helpers.py
+++ b/src/tests/helpers.py
@@ -1,8 +1,10 @@
 import json
 
+
 def set_assert_field_exists(field, data):
     if field in data:
         data[field] = "assert-field-exists"
+
 
 def strip_api_fields(data):
     """
@@ -35,7 +37,9 @@ def assert_expected(response, expected):
         print(json.dumps(strip_api_fields(response.json()), indent=2))
         print("EXP")
         print(json.dumps(strip_api_fields(expected), indent=2))
-        assert strip_api_fields(response.json()) == strip_api_fields(expected["response"])
+        assert strip_api_fields(response.json()) == strip_api_fields(
+            expected["response"]
+        )
     else:
         print(response.content.decode("utf-8"))
         assert response.content.decode("utf-8") == expected["response"]

--- a/src/tests/test_account_api.py
+++ b/src/tests/test_account_api.py
@@ -1,6 +1,5 @@
 import json
 
-import pytest
 from django.contrib.auth import authenticate
 from django.urls import reverse
 
@@ -252,9 +251,19 @@ def test_org_userdel(db, account_objects, data_account_api_org_userdel):
     data = {}
 
     if data_account_api_org_userdel.name == "test0":
-        data.update(id=account_objects.user_unpermissioned.org_user_set.filter(org=account_objects.org).first().id)
+        data.update(
+            id=account_objects.user_unpermissioned.org_user_set.filter(
+                org=account_objects.org
+            )
+            .first()
+            .id
+        )
     else:
-        data.update(id=account_objects.user.org_user_set.filter(org=account_objects.org).first().id)
+        data.update(
+            id=account_objects.user.org_user_set.filter(org=account_objects.org)
+            .first()
+            .id
+        )
 
     response = account_objects.api_client.delete(
         reverse("account_api:org-user", args=(slug,)),
@@ -294,7 +303,13 @@ def test_org_set_permissions(db, account_objects, data_account_api_org_setperm):
     expected = data_account_api_org_setperm.expected
     slug = input.get("slug", account_objects.org.slug)
 
-    input["data"].update(id=account_objects.user_unpermissioned.org_user_set.filter(org=account_objects.org).first().id)
+    input["data"].update(
+        id=account_objects.user_unpermissioned.org_user_set.filter(
+            org=account_objects.org
+        )
+        .first()
+        .id
+    )
 
     response = getattr(account_objects, input["client"]).put(
         reverse("account_api:org-set-permissions", args=(slug,)), data=input["data"]


### PR DESCRIPTION
Coverage file was not generating because of an error in permissions when mounting the volume in docker.
Solved by adding feature to pass in user arg(-u) through run.sh to docker-compose command, then using that feature in the GitHub workflow by passing current user.

Fixes: #49 