### PR TITLE
fix personal org slugs and names

### DIFF
--- a/src/account/admin.py
+++ b/src/account/admin.py
@@ -135,7 +135,7 @@ class OrganizationRoleInline(admin.TabularInline):
 
 @admin.register(Organization)
 class OrganizationAdmin(admin.ModelAdmin):
-    list_display = ("name", "user")
+    list_display = ("name", "user", "slug")
     search_fields = ("org_user_set__last_name", "name")
 
     def get_inlines(self, request, obj=None):

--- a/src/account/forms.py
+++ b/src/account/forms.py
@@ -182,7 +182,8 @@ class EditOrganization(CreateOrganization):
 
         if org.user_id:
             self.fields["name"].widget.attrs["readonly"] = True
-            self.initial["name"] = _("Your Personal Organization")
+            self.fields["slug"].widget.attrs["readonly"] = True
+            self.initial["name"] = org.user.username + " (Personal)"
 
 
 class EditOrganizationPasswordProtected(PasswordProtectedForm, EditOrganization):

--- a/src/account/management/commands/aaactl_fix_personal_org_slugs.py
+++ b/src/account/management/commands/aaactl_fix_personal_org_slugs.py
@@ -1,0 +1,19 @@
+from fullctl.django.management.commands.base import CommandInterface
+
+from account.models import Organization, generate_org_slug
+
+
+class Command(CommandInterface):
+
+    """
+    Loops through all personal orgs and randomizes their slugs and sets
+    org name to the owning user's name
+    """
+
+    def run(self, *args, **kwargs):
+        # update all orgs
+        for org in Organization.objects.exclude(user__isnull=True):
+            self.log_info(f"Fixing personal org {org.id} {org.name} {org.slug}")
+            org.name = org.user.username
+            org.slug = generate_org_slug()
+            org.save()

--- a/src/account/models.py
+++ b/src/account/models.py
@@ -109,16 +109,8 @@ class Organization(HandleRefModel):
         except OrganizationUser.DoesNotExist:
             pass
 
-        if not cls.objects.filter(slug=user.username).exists():
-            slug = user.username
-            slug = slug.replace(".", "_").replace("@", "AT")
-        else:
-            slug = generate_org_slug()
-
-        org, created = cls.objects.get_or_create(user=user, slug=slug)
-
-        if created:
-            org.add_user(user, "crud")
+        org = cls.objects.create(user=user, name=user.username)
+        org.add_user(user, "crud")
 
         return org
 
@@ -169,6 +161,10 @@ class Organization(HandleRefModel):
         if self.user_id:
             return _("Your Personal Organization")
         return self.name
+
+    @property
+    def is_personal(self):
+        return self.user_id is not None
 
     def __str__(self):
         return self.label

--- a/src/account/rest/views.py
+++ b/src/account/rest/views.py
@@ -256,6 +256,14 @@ class Organization(viewsets.ViewSet):
     @grainy_endpoint("org.{org.id}.manage", explicit=False)
     def update(self, request, pk, org, auditlog=None):
         user = request.user
+
+        # personal organizations cannot be edited
+        if org.is_personal:
+            return Response(
+                {"non_field_errors": [_("Personal organizations cannot be changed.")]},
+                status=403,
+            )
+
         if user.has_usable_password():
             serializer = Serializers.orgeditpwdprotected(
                 instance=org,

--- a/src/account/templates/account/controlpanel/edit-organization-modal.html
+++ b/src/account/templates/account/controlpanel/edit-organization-modal.html
@@ -19,9 +19,19 @@
         <div data-api-submit="yes">
         {{ edit_org_form|crispy }}
         </div>
+        {% if request.selected_org.user %}
+        <div class="center">
+          <div class="alert alert-info">
+            {% blocktrans %}
+            Personal organizations cannot be edited.
+            {% endblocktrans %}
+          </div>
+        </div>
+        {% else %}
         <div class="right">
           <button type="button" class="btn btn-manage submit">{% trans "Save" %}</button>
         </div>
+        {% endif %}
         </form>
       </div>
     </div>

--- a/src/account/views/controlpanel.py
+++ b/src/account/views/controlpanel.py
@@ -31,6 +31,11 @@ def index(request):
 
     if user.has_usable_password():
         change_pwd_form = account.forms.ChangePassword(user)
+    else:
+        change_pwd_form = account.forms.ChangePasswordBase()
+        env.update(initial_password=True)
+
+    if user.has_usable_password() and not request.selected_org.is_personal:
         edit_org_form = account.forms.EditOrganizationPasswordProtected(
             user,
             request.selected_org,
@@ -40,8 +45,6 @@ def index(request):
             },
         )
     else:
-        change_pwd_form = account.forms.ChangePasswordBase()
-        env.update(initial_password=True)
         edit_org_form = account.forms.EditOrganization(
             request.selected_org,
             initial={
@@ -49,6 +52,7 @@ def index(request):
                 "slug": request.selected_org.slug,
             },
         )
+
     env.update(
         change_user_info_form=form,
         change_pwd_form=change_pwd_form,


### PR DESCRIPTION
- randomizes url slug for personal orgs during creation
- sets orgname to be the user name
- editing personal org name and slug after creation is no longer allowed
- adds management command to retroactively fix existing personal org slugs and names