### PR TITLE
fix database constraint that would prevent removal of product from subscription

### DIFF
--- a/src/billing/models.py
+++ b/src/billing/models.py
@@ -2119,7 +2119,7 @@ class OrderLine(Transaction):
     )
     subscription_cycle_product = models.ForeignKey(
         "billing.SubscriptionCycleProduct",
-        on_delete=models.PROTECT,
+        on_delete=models.SET_NULL,
         related_name="order_set",
         null=True,
         blank=True,
@@ -2167,7 +2167,7 @@ class InvoiceLine(Transaction):
     )
     subscription_cycle_product = models.ForeignKey(
         "billing.SubscriptionCycleProduct",
-        on_delete=models.PROTECT,
+        on_delete=models.SET_NULL,
         related_name="invoice_set",
         blank=True,
         null=True,


### PR DESCRIPTION
both order and invoice lines already copy the relevant info to dedicated fields and protecting the reference here means we can't remove stuff from subscriptions